### PR TITLE
replace sapply with more appropriate function

### DIFF
--- a/R/weekreport.R
+++ b/R/weekreport.R
@@ -57,7 +57,7 @@ week_report <- function(current_week = "2018-W35",
   processed_data <- purrr::map(processed_data, clean_data)
 
   ## pull country name from first row of country variable
-  cleaned_names <- sapply(processed_data, function(x) x$country[1L])
+  cleaned_names <- purrr::map_chr(purrr::map(processed_data, "country"), 1L)
 
   ## overwrite names in processed_data to be simplified country names
   names(processed_data) <- cleaned_names


### PR DESCRIPTION
Don't use sapply because it tries to "guess" what your result is and can result in failures.

There are other ways of approaching this as well:

```r
cleaned_names <- vapply(processed_data, function(x) x$country[1], FUN.VALUE = character(1))
```


```r
cleaned_names <- purrr::map_chr(.x = processed_data, ~.x$country[1])
```